### PR TITLE
Fix JS error and broken scrollreveal due to typo

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -84,8 +84,8 @@
       sr.reveal('#fonctionnalites', block);
       sr.reveal('#parallax', block);
       sr.reveal('#avantages', block);
-      srpropos.reveal('#relais', block);
-      sr.reveal('#a-', block);
+      sr.reveal('#relais', block);
+      sr.reveal('#a-propos', block);
       sr.reveal('#contact', block);
     });
     </script>


### PR DESCRIPTION
Je suis tombé sur ça en ouvrant la console de www.promomaker.fr 

![Selection_003](https://user-images.githubusercontent.com/5930831/206680289-7937f4fb-8708-4093-abc2-cce9baccdca1.png)
