### PR TITLE
Kozea 2317 : Mise à jour de l'adresse

### DIFF
--- a/templates/legal.html
+++ b/templates/legal.html
@@ -23,7 +23,7 @@
         <dt>SIREN</dt>
         <dd>508 023 694</dd>
         <dt>Adresse</dt>
-        <dd>107 boulevard Stalingrad, 69100 Villeurbanne</dd>
+        <dd>75 Rue de la République, 69002 Lyon</dd>
         <dt>Capital social</dt>
         <dd>33 000 €</dd>
         <dt>Numéro de TVA intracommunautaire</dt>
@@ -102,10 +102,9 @@
         par mail à l’adresse
         <a href="mailto:promomaker@kozea.fr">promomaker@kozea.fr</a>
         ou par courrier à l’adresse du siège social de Pegasus Network à
-        l’adresse suivante : 107 boulevard Stalingrad 69100
-        Villeurbanne. Le responsable du fichier, effectuera une réponse
-        au plus tard dans le mois suivant la demande d’accès ou de
-        rectification.
+        l’adresse suivante : 75 Rue de la République, 69002 Lyon. Le
+        responsable du fichier, effectuera une réponse au plus tard dans
+        le mois suivant la demande d’accès ou de rectification.
       </p>
 
       <h3>Sécurité des données et traitements (art. 29 du RGPD)</h3>

--- a/templates/legal.html
+++ b/templates/legal.html
@@ -23,7 +23,7 @@
         <dt>SIREN</dt>
         <dd>508 023 694</dd>
         <dt>Adresse</dt>
-        <dd>75 Rue de la République, 69002 Lyon</dd>
+        <dd>75 Rue de la République, BP 2433, 69216 Lyon Centre PPDC</dd>
         <dt>Capital social</dt>
         <dd>33 000 €</dd>
         <dt>Numéro de TVA intracommunautaire</dt>
@@ -102,9 +102,9 @@
         par mail à l’adresse
         <a href="mailto:promomaker@kozea.fr">promomaker@kozea.fr</a>
         ou par courrier à l’adresse du siège social de Pegasus Network à
-        l’adresse suivante : 75 Rue de la République, 69002 Lyon. Le
-        responsable du fichier, effectuera une réponse au plus tard dans
-        le mois suivant la demande d’accès ou de rectification.
+        l’adresse suivante : 75 Rue de la République, BP 2433, 69216 Lyon
+        Centre PPDC. Le responsable du fichier, effectuera une réponse au
+        plus tard dans le mois suivant la demande d’accès ou de rectification.
       </p>
 
       <h3>Sécurité des données et traitements (art. 29 du RGPD)</h3>


### PR DESCRIPTION
# :warning: :x: Ne pas merger avant accord de la direction pour des raisons légales :x::warning:

Lié à https://github.com/Kozea/kozea/issues/2317

- [x] Adresse légale => BP 2433
- [x] SIREN uniquement dans les mentions légales, pas de SIRET

![image](https://github.com/user-attachments/assets/a3de4ed0-f483-420c-b468-511b53ec841f)
